### PR TITLE
Validation fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,34 +204,34 @@
         <dfn data-export="">posture</dfn> values:
       </p>
       <ol class="postures">
-        <img src="images/nofold-mode-graphic.svg" class="drawing" alt="drawing of no-fold mode">
         <li>
+          <img src="images/nofold-mode-graphic.svg" class="drawing" alt="drawing of no-fold mode">
           <a>No-Fold</a> is the posture of a device without a hinge. 
           This is the expected value for devices that do not fold.
         </li>
-        <img src="images/laptop-mode-graphic.svg" class="drawing" alt="drawing of laptop mode">
         <li>
+          <img src="images/laptop-mode-graphic.svg" class="drawing" alt="drawing of laptop mode">
           <a>Laptop</a> posture indicates that the device is being used as
           a traditional laptop, meaning one screen is placed on a more or
           less horizontal surface with a screen angle between 180 to 0 degrees.
         </li>
-        <img src="images/flat-mode-graphic.svg" class="drawing" alt="drawing of flat mode">
         <li>
+          <img src="images/flat-mode-graphic.svg" class="drawing" alt="drawing of flat mode">
           <a>Flat</a> posture indicates that one screen is being placed on
           a more or less horizontal surface with a screen angle around 180 degrees.
         </li>
-        <img src="images/tent-mode-graphic.svg" class="drawing" alt="drawing of tent mode">
         <li>
+          <img src="images/tent-mode-graphic.svg" class="drawing" alt="drawing of tent mode">
           <a>Tent</a> posture indicates that the edges of both screens are placed
           on a horizontal surface but with an angle > 180 degrees.
         </li>        
-        <img src="images/tablet-mode-graphic.svg" class="drawing" alt="drawing of tablet mode">
         <li>
+          <img src="images/tablet-mode-graphic.svg" class="drawing" alt="drawing of tablet mode">
           <a>Tablet</a> posture is when the device can turn around on its hinge all the way to have
           the screen back to back. The angle is considered to be around 360 degrees.
         </li>
-        <img src="images/book-mode-graphic.svg" class="drawing" alt="drawing of book mode">
         <li>
+          <img src="images/book-mode-graphic.svg" class="drawing" alt="drawing of book mode">
           <a>Book</a> posture is when the device is used between around 50 and 160 degrees. 
           It is generally used while being held on (not on a surface).
         </li>
@@ -339,7 +339,7 @@
 
         <p>Some devices might also lack one or more of the postures due to physical constraints or device design, in which case the device SHOULD make sure that all combinations of angles and device orientation (which can be locked by [[SCREEN-ORIENTATION]] and host OS) maps into one of the defined postures.</p>
       <p>
-        <img src="images/angle-graphic.svg">
+        <img src="images/angle-graphic.svg" alt="An illustration on how posture values are derived from the orientation of the fold">
         The <a>posture values table</a> shows how the {{posture}}
         values are derived depending on the orientation of the fold:
       </p>
@@ -788,7 +788,7 @@
         enable a hands-free when placed on a surface. The UA detects the posture and the UI is enhanced.
         Similar examples can be drafted for content to adapt to any posture. See the <a href="https://github.com/SamsungInternet/Explainers/blob/master/Foldables/FoldState.md#key-scenarios">explainer</a> for other key scenarios.
       </p>
-      <img src="images/example-videocall.svg" class="img-example" >
+      <img src="images/example-videocall.svg" alt="An illustration of a video call web service that uses the screen-fold-posture media feature" class="img-example" >
       <pre class="example css" title="Adapting UI to posture">
         @media (screen-fold-posture: laptop) and (spanning: single-fold-horizontal){
           body {

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
          or horizontal way.    
       </p>
       <span class="centered">
-        <img src="images/form-factors.svg" height="150px" alt="drawing of different type of foldable devices">
+        <img src="images/form-factors.svg" height="150" alt="drawing of different type of foldable devices">
       </span>
       <p>
         From enhancing the usability of a website by avoiding the area of a fold, to enabling innovative use cases for the 
@@ -242,8 +242,8 @@
       </p>
     </section>
     <section data-link-for="ScreenFoldPosture">
-      <h3>Screen Fold Media Queries</h3>
-      <h4>
+      <h2>Screen Fold Media Queries</h2>
+      <h3>
         The <code>'screen-fold-posture'</code> media feature
       </h3>
       <p>
@@ -344,7 +344,7 @@
         values are derived depending on the orientation of the fold:
       </p>
       <h4>Horizontal Fold</h4>
-      <span class="postures">
+      <div class="postures">
         <img src="images/horizontal-fold.svg" class="drawing" alt="drawing of a device with a vertical fold">
         <p>
           Devices with a horizontal fold are the ones for which in their 
@@ -352,7 +352,7 @@
         the screen(s).
         </p>
         
-      </span>
+      </div>
         <table class="simple">
         <caption>
           The posture values table for devices with a horizontal fold
@@ -429,13 +429,13 @@
         </tbody>
       </table>
       <h4>Vertical Fold</h4>
-      <span class="postures">
+      <div class="postures">
         <img src="images/vertical-fold.svg" class="drawing" alt="drawing of a device with a horizontal fold">
         <p>
           Devices with a vertical fold are the ones for which in their main form 
           factor, the folding occurs from top to bottom, across the screen(s).
         </p>
-      </span>
+      </div>
       <table class="simple">
         <caption>
           The posture values table for devices with a vertical fold
@@ -621,6 +621,7 @@
       </h2>
       <p>
         The Screen Fold API exposes two kinds of information:
+      </p>
         <ol class="algorithm">
           <li>
             an <a href="#the-angle-attribute-get-current-screen-fold-angle">angle</a> value
@@ -630,7 +631,6 @@
             A <a>posture</a> determined from the angle value
           </li>
         </ol>
-      </p>
       <p>
         Typical sensor readings are sent at a constant frequency to whomever is listening to its readings.
         However the fold angle only communicates its value when the hinge is manipulated by the user.


### PR DESCRIPTION
This PR fixes some (but not all) of the validation errors that block the publication of the spec.

There are some other errors that I am not sure how to fix, such as "Element `img` not allowed as child of element `ol` in this context." in [line 207](https://github.com/w3c/screen-fold/blob/54eac38fc39cf617945cdc12138a7bba158c5130/index.html#L207) (should we move it into the `li`?), and `alt` attribute for a few images.

See details here: https://validator.w3.org/nu/?doc=https%3A%2F%2Fw3c.github.io%2Fscreen-fold%2F


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-fold/pull/50.html" title="Last updated on Dec 12, 2020, 1:58 AM UTC (e6ee059)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-fold/50/9090b06...e6ee059.html" title="Last updated on Dec 12, 2020, 1:58 AM UTC (e6ee059)">Diff</a>