### PR TITLE
Fixes after renaming.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,20 @@
 
 ## Abstract
 
-This document specifies an API that allows web applications to request the angular value to which a device with a screen hinge is folded. Under the right conditions, and if allowed, the value representing the angle in degrees is returned.
+ This document specifies an API that allows web applications to request and be notified of changes of the posture of a foldable device.
 
 ## Goals
 
 Foldable devices come in many shapes and sizes. While the use cases for the ultrabooks of the past vary significantly from those of the new trend of mobile devices due to the inherent focus on screen real estate, **the data in question is similar since it’s related to the angle of the fold**.
 
-The **main interest in knowing the fold angle is because there are interesting opportunities in the area of responsive design that enable new user experiences**. With these new devices, the user can choose to consume content and browse the web even when the device is not flat, in which case the developer might want to provide a different layout for the content depending on the state of the angle of the fold. We propose a way to expose information about the fold angle of the device to the developer. Additionally, developers would like to adopt content depending on the various modes and potentially also animate some of these transitions.
+The **main interest in knowing the device posture is because there are interesting opportunities in the area of responsive design that enable new user experiences**. With these new devices, the user can choose to consume content and browse the web even when the device is not flat, in which case the developer might want to provide a different layout for the content depending on how the device is being used. We propose a way to expose information about the posture of the device to the developer.
 
 ## Proposals
-
-### New CSS media query: `screen-fold-angle` 
-
-In order to cater to foldable devices, we propose the addition of 2 new media queries `min-angle` and `max-angle` which values can take an angle from the CSS data type.
-
-#### Examples
-
-```css
-@media(min-screen-fold-angle: 110deg) { ... }
-
-@media(max-screen-fold-angle: 170deg) and (spanning: single-fold-vertical) { ... }
-```
-
-### New CSS media query: `screen-fold-posture`
+### New CSS media query: `device-posture`
 
 We also propose a media query that would resolve to a set of fixed postures. These postures consist of a number of predefined values that each encompass a range of angles.
 
-Among the values that the screen-posture query can take are:
+Among the values that the device-posture query can take are:
 * No Fold
 * Laptop
 * Tent
@@ -48,33 +35,23 @@ Among the values that the screen-posture query can take are:
 #### Examples
 
 ```css
-@media (screen-fold-posture: laptop) { ... }
+@media (device-posture: laptop) { ... }
 
 /*for a monitor scenario*/
-@media (screen-fold-posture: flat) and (orientation: portrait) { ... }
+@media (device-posture: flat) and (orientation: portrait) { ... }
 ```
-
-### New CSS environmental variable: screen-fold-angle
-
-We also propose the addition of a new environmental variable, ‘screen-fold-angle’, which contains the value of the angle on which the screen is folded. The value of this environmental variable is of the CSS angle data type.
-
-```css
-env(screen-fold-angle);
-```
-
-### New JS object in `window.screen`: `ScreenFold`
+### New JS object in `window.screen`: `posture`
 
 The Window property screen returns a reference to the screen object associated with the window. It already houses a similar property [`orientation`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation) that itself has a value for an [angle](https://w3c.github.io/screen-orientation/#idl-index).
 
 #### Proposed Object
 ```javascript
-ScreenFold : EventTarget {
-  readonly attribute unsigned short angle;
-  readonly attribute ScreenFoldMode mode;
+DevicePosture : EventTarget {
+  readonly attribute DevicePostureType type;
   attribute EventHandler onchange;
 }
 
-enum ScreenFoldMode {
+enum DevicePostureType {
   "laptop",
   “...”,
 }

--- a/index.html
+++ b/index.html
@@ -149,10 +149,17 @@
     </section>
     <section data-dfn-for="DevicePosture">
       <h2>
-        The <dfn>DevicePosture</dfn> attribute
+        The <dfn>DevicePosture</dfn> interface
       </h2>
       <pre class="idl">
-        enum DevicePosture {
+
+        [SecureContext, Exposed=(Window)]
+        interface DevicePosture : EventTarget {
+          readonly attribute DevicePostureType type;
+          attribute EventHandler onchange;
+        };
+
+        enum DevicePostureType {
           "no-fold",
           "laptop",
           "flat",
@@ -161,10 +168,13 @@
           "book"
         };
       </pre>
-      <p>
-        When getting the type attribute, the user agent MUST return the
-        [=environment settings object/responsible document=]'s current device {{posture}}.
-      </p>
+      <section>
+        <h3>The <dfn>type</dfn> attribute: Get current device posture</h3>
+        <p>
+          When getting the type attribute, the user agent MUST return the
+          [=environment settings object/responsible document=]'s current {{posture}}.
+        </p>
+      </section>
       <section>
         <h3>The <dfn>onchange</dfn> attribute: Handle posture changes</h3>
         <p data-link-for="DevicePosture">
@@ -173,7 +183,7 @@
         </p>
       </section>
     </section>
-    <section data-link-for="DevicePosture">
+    <section data-link-for="DevicePostureType">
       <h2>
         Posture modes
       </h2>
@@ -219,7 +229,7 @@
         {{DevicePosture}} enum values.
       </p>
     </section>
-    <section data-link-for="DevicePosture">
+    <section data-link-for="DevicePostureType">
       <h2>Device Posture Media Queries</h2>
       <h3>
         The <code>'device-posture'</code> media feature
@@ -311,7 +321,7 @@
         </thead>
         <tbody>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Laptop</a>
             </td>
             <td>
@@ -322,7 +332,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Flat</a>
             </td>
             <td>
@@ -333,7 +343,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Tent</a>
             </td>
             <td>
@@ -344,7 +354,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Tablet</a>
             </td>
             <td>
@@ -355,7 +365,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Book</a>
             </td>
             <td>
@@ -394,7 +404,7 @@
         </thead>
         <tbody>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Laptop</a>
             </td>
             <td>
@@ -405,7 +415,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Flat</a>
             </td>
             <td>
@@ -416,7 +426,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Tent</a>
             </td>
             <td>
@@ -427,7 +437,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Tablet</a>
             </td>
             <td>
@@ -438,7 +448,7 @@
             </td>
           </tr>
           <tr>
-            <td data-link-for="DevicePosture">
+            <td data-link-for="DevicePostureType">
               <a>Book</a>
             </td>
             <td>
@@ -631,7 +641,7 @@
       <p>This is a simple use case of the <a>posture</a> being printed on the console. </p>
       <pre class="example js" title="React to poster change">
           screen.posture.addEventListener("change", () => {
-            console.log(`The current posture is: ${screen.posture}!`);
+            console.log(`The current posture is: ${screen.posture.type}!`);
           })
       </pre>
       <h3>Example 2: device-posture</h3>


### PR DESCRIPTION
- Updated the README.md to reflect the new specification
- Updated the specification to fix the new DevicePostureType, this means that the API is meant to be used as : window.screen.posture.type which is following the pattern of window.screen.orientation.type.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darktears/device-posture/pull/62.html" title="Last updated on Mar 10, 2021, 3:06 PM UTC (06142c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/62/128c528...darktears:06142c3.html" title="Last updated on Mar 10, 2021, 3:06 PM UTC (06142c3)">Diff</a>