### PR TITLE
Fix name of enum values

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
       </ol>
       <p>
         In the API, the [=posture=] values are represented by the
-        {{DevicePosture}} enum values.
+        {{DevicePostureType}} enum values.
       </p>
     </section>
     <section data-link-for="DevicePostureType">


### PR DESCRIPTION
This PR fixes the name of the enum values used for device posture. It should be `DevicePostureType`, not `DevicePosture`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/device-posture/pull/65.html" title="Last updated on Mar 16, 2021, 2:28 PM UTC (86ba9ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/65/c3fc21c...beaufortfrancois:86ba9ff.html" title="Last updated on Mar 16, 2021, 2:28 PM UTC (86ba9ff)">Diff</a>