### PR TITLE
Update URL of the drawing of different postures

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Many thanks for valuable feedback and advice from:
 * [Jo Balletti](https://twitter.com/thisisjofrank), [Ably Realtime](https://ably.io)
 * [Michael Blix](https://twitter.com/mkeblx), [Samsung](https://samsunginter.net) 
 
-!['drawing of different postures'](https://github.com/w3c/screen-fold/blob/gh-pages/images/postures.png?raw=true)
+!['drawing of different postures'](https://github.com/w3c/device-posture/blob/gh-pages/images/postures.png?raw=true)


### PR DESCRIPTION
This PR fixes a nit after renaming the spec from "screen-fold" to "device-posture".