### PR TITLE
Remove Folded Over from Device Posture

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,8 +223,7 @@
 
         enum DevicePostureType {
           "continuous",
-          "folded",
-          "folded-over"          
+          "folded"      
         };
       </pre>
       <section>
@@ -317,22 +316,6 @@
             </li>
           </ul>
         </li>
-        <li>
-          <img src="images/folded-over-posture.svg" class="drawing" alt=
-          "drawing of the folded over posture"> <a>Folded-over</a> posture: The
-          folded-over posture is when the device is physically folded and the
-          screens/sections surpass the ~200° angle. It is also known as the
-          'tent' posture when the device is being used with its hinge parallel
-          to a surface.
-          <p>
-            Examples of these are:
-          </p>
-          <ul>
-            <li>2-in-1 device on a surface displaying content for users on each
-            side of the device (games).
-            </li>
-          </ul>
-        </li>
       </ol>
       <p>
         In the API, the [=posture=] values are represented by the
@@ -358,7 +341,7 @@
           Value:
         </dt>
         <dd>
-          <a>continuous</a> | <a>folded</a> | <a>folded-over</a>
+          <a>continuous</a> | <a>folded</a>
         </dd>
         <dt>
           Applies to:
@@ -444,14 +427,6 @@
           </td>
           <td>
             ~180°
-          </td>
-        </tr>
-        <tr>
-          <td>
-            folded-over
-          </td>
-          <td>
-            &gt; ~180°
           </td>
         </tr>
       </table>


### PR DESCRIPTION
Remove the Folded Over posture because it has 2 meanings as described.
The document references "tent-mode" which typically means the device is propped up like a tent.   Tent mode does not require a secondary display, consider a Samsung Galaxy Fold that is propped open a little like an alarm clock.

A folded over position would be very challenging for developers to support generally.  If it is implemented consistently with the other APIs this means that developers will need to manually split and transform their content.

Closes #???

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=) 
 * Gecko - Waiting on [standards position](https://github.com/mozilla/standards-positions/issues/210) before committing.
 * WebKit - Not participating in this working group.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 3, 2023, 9:54 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsupo2co%2Fdevice-posture%2F443229e94bb6f79c8a38dc0e97dd059366b312b9%2Findex.html%3FisPreview%3Dtrue)

```
🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: https://labs.w3.org/spec-generator/uploads/Wc3vSu/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-04-03
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/device-posture%23100.)._
</details>
