### PR TITLE
fix "active document" cite

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,7 +493,7 @@
           <li>[=list/for each=] |context:browsing context| in |browsing
           contexts|, run the following sub-steps:
             <ol>
-              <li>Let |document| be the |context|'s <a>active document</a>.
+              <li>Let |document| be the |context|'s [=navigable/active document=].
               </li>
               <li>If |document| is not visible per [[PAGE-VISIBILITY]], abort
               these steps.


### PR DESCRIPTION
fix for https://github.com/w3c/device-posture/pull/102#issuecomment-1493878016

no normative/substantive change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/device-posture/pull/105.html" title="Last updated on Apr 3, 2023, 8:43 AM UTC (88e4069)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/105/067e33a...himorin:88e4069.html" title="Last updated on Apr 3, 2023, 8:43 AM UTC (88e4069)">Diff</a>