### PR TITLE
Remove the policy control part from the spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,9 +49,6 @@
         }],
         xref: {
           profile: "web-platform",
-          specs: [
-            "permissions-policy"
-          ]
         },
         logos: [
         {
@@ -537,41 +534,6 @@
           54</a>.
         </div>
       </section>
-    </section>
-    <section>
-      <h3>
-        Policy control
-      </h3>
-      <p>
-        The Device Posture API defines a [=policy-controlled feature=]
-        identified by the token "device-posture".
-        Its [=policy-controlled feature/default allowlist=] is `'self'`.
-      </p>
-      <aside class="note">
-        <p>
-          The [=policy-controlled feature/default allowlist=] of `'self'` allows usage in
-          same-origin nested frames but prevents third-party content from using
-          the feature.
-        </p>
-        <p>
-          Third-party usage can be selectively enabled by adding
-          `allow="device-posture"` attribute to the frame container element:
-        </p>
-        <pre class="example html" title=
-        "Enabling device posture on remote content">
-          &lt;iframe src="https://third-party.com" allow="device-posture"/&gt;&lt;/iframe&gt;
-        </pre>
-        <p>
-          Alternatively, the Device Posture API can be disabled completely by
-          specifying the permissions policy in a HTTP response header:
-        </p>
-        <pre class="example http" title="Feature Policy over HTTP">
-          Permissions-Policy: {"device-posture": []}
-        </pre>
-        <p>
-          See [[[PERMISSIONS-POLICY]]] for more details.
-        </p>
-      </aside>
     </section>
     <section>
       <h2>

--- a/security-privacy-self-assessment.md
+++ b/security-privacy-self-assessment.md
@@ -58,8 +58,7 @@ The device posture API could be used to identify whether the device is a foldabl
 
 ### 2.13. How does this specification distinguish between behavior in first-party and third-party contexts?
 
-The specified API will be available in third-part contexts via iframe
-guarded by permission policy and focus requirements. The API is also only available in secure contexts.
+The specified API will be available in third-party contexts via iframe either through CSS or JavaScript.
 
 ### 2.14. How does this specification work in the context of a user agent’s Private Browsing or "incognito" mode?
 


### PR DESCRIPTION
We can only gate properly a JavaScript API by throwing a NotAllowed error. Unfortunately there is no mechanism or previous examples where a CSS is "gated" behind a Permission Policy and it raises questions on how such implementation would work (how to tell developers that the CSS MQs are not evaluated because of the policy control)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darktears/device-posture/pull/114.html" title="Last updated on Mar 8, 2024, 1:07 PM UTC (888d3dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/114/e28aa19...darktears:888d3dc.html" title="Last updated on Mar 8, 2024, 1:07 PM UTC (888d3dc)">Diff</a>