### PR TITLE
editorial: Do not define Navigator, just reference it

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,8 +208,8 @@
         Extensions to the `Navigator` interface
       </h2>
       <p>
-        The [[HTML]] specification defines the <dfn>Navigator</dfn> interface,
-        which this specification extends:
+        The [[HTML]] specification defines the {{Navigator}} interface, which
+        this specification extends:
       </p>
       <pre class="idl">
         [SecureContext, Exposed=(Window)]


### PR DESCRIPTION
Navigator is <dfn>ed in HTML; redefining it here does not make much sense as
we just need to reference the original definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/device-posture/pull/116.html" title="Last updated on Mar 8, 2024, 5:43 PM UTC (a70ea5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/116/8d38b2a...rakuco:a70ea5f.html" title="Last updated on Mar 8, 2024, 5:43 PM UTC (a70ea5f)">Diff</a>