### PR TITLE
editorial: Use navigables, not browsing contexts, in CSS media feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,10 +340,9 @@
       </h3>
       <p>
         The <code><dfn>device-posture</dfn></code> media feature represents,
-        via a CSS media query [[MEDIAQ]], the <a>posture</a> of the device.
-        This media feature applies to the top-level browsing context and any
-        child browsing contexts. Child browsing contexts reflect the
-        <a>posture</a> of the <a>top-level browsing context</a>.
+        via a CSS media query [[MEDIAQ]], the <a>posture</a> of the device. All
+        <a>navigables</a> reflect the <a>posture</a> of their
+        [=navigable/top-level traversable=].
       </p>
       <dl>
         <dt>


### PR DESCRIPTION
Related to #104.

The end result is the same, but we now avoid using deprecated terms. The
text has also been simplified: saying that something applies to the
top-level browsing context and all child contexts is redundant (it basically
says it applies to all pages); the relevant point which is that navigables
that are not top-level traversables reflect the latter's value, has been
kept.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/device-posture/pull/119.html" title="Last updated on Mar 8, 2024, 5:54 PM UTC (7d5946c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/119/8d38b2a...rakuco:7d5946c.html" title="Last updated on Mar 8, 2024, 5:54 PM UTC (7d5946c)">Diff</a>