### PR TITLE
Remove additional logos to keep consistent with other W3C specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <img width="247" alt="favicon" src="https://user-images.githubusercontent.com/73939538/123794912-4c089380-d8db-11eb-811b-7367461cfdd4.png">
+<img width="330" alt="favicon" src="images/daswg-logo.svg">
 
 # Device Posture API
 

--- a/index.html
+++ b/index.html
@@ -49,25 +49,7 @@
         }],
         xref: {
           profile: "web-platform",
-        },
-        logos: [
-        {
-          src: "./images/daswg-logo.svg",
-          url: "https://www.w3.org/das/",
-          alt: "Devices and Sensors WG logo",
-          width: 100,
-          height: 100,
-          id: "das-logo",
-        },
-        {
-          src: "./images/dp-logo-title.svg",
-          url: "",
-          alt: "Device Posture API logo",
-          width: 100,
-          height: 100,
-          id: "device-posture-logo",
-        }
-      ], 
+        }, 
       };
     </script>
     <style>


### PR DESCRIPTION
Additional logos are added only when partnering with another standard body. The logos are now in the README.md.

Closes #90


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darktears/device-posture/pull/121.html" title="Last updated on Mar 11, 2024, 3:54 PM UTC (4896cf3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/121/d88a411...darktears:4896cf3.html" title="Last updated on Mar 11, 2024, 3:54 PM UTC (4896cf3)">Diff</a>