### PR TITLE
Fix ReSpec warning on device-posture Media Query

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,10 +319,10 @@
         Device Posture Media Queries
       </h2>
       <h3>
-        The <code>'device-posture'</code> media feature
+        The <code><dfn>device-posture</dfn></code> media feature
       </h3>
       <p>
-        The <code><dfn>device-posture</dfn></code> media feature represents,
+        The <code>[=device-posture=]</code> media feature represents,
         via a CSS media query [[MEDIAQ]], the <a>posture</a> of the device. All
         <a>navigables</a> reflect the <a>posture</a> of their
         [=navigable/top-level traversable=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darktears/device-posture/pull/122.html" title="Last updated on Mar 11, 2024, 4:20 PM UTC (272fb7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/122/110d513...darktears:272fb7b.html" title="Last updated on Mar 11, 2024, 4:20 PM UTC (272fb7b)">Diff</a>