### PR TITLE
Remove the rate limiting section per PING review.

### DIFF
--- a/index.html
+++ b/index.html
@@ -613,8 +613,7 @@
         </p>
         <p>
           This theoretical attack is mitigated by [[[#data-minimization]]],
-          [[[#user-attention]]], [[[#user-mediated-action]]] and
-          [[[#rate-limiting-change-notifications]]].
+          [[[#user-attention]]] and [[[#user-mediated-action]]].
         </p>
         <h4>
           Cross-origin iframes
@@ -685,21 +684,6 @@
             per [=posture values table=], and explicit, because the underlying
             operating system adapts to posture changes similarly matching
             user's learned expectations for an outcome of such an action.
-          </p>
-        </section>
-        <section>
-          <h4 id="rate-limiting-change-notifications">
-            Rate-limiting change notifications
-          </h4>
-          <p>
-            The API is designed to minimize the rate at which posture state
-            changes are reported. A change is only reported throught this API
-            when an implementation-defined threshold is crossed per [=posture
-            values table=]. Given the small number of states and a wide range
-            of angles that correlate with the default
-            "{{DevicePostureType/continuous}}" state, the rate of notifications
-            is limited. We playfully call this mitigation a physical
-            human-computer interface rate limiter.
           </p>
         </section>
       </section>


### PR DESCRIPTION
We don't have rate limiting mechanism since the posture changes are triggered by a human interaction (opening/closing the device for example). Also posture changes are not happening often and rapidly.

Closes #154


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/darktears/device-posture/pull/155.html" title="Last updated on Jul 22, 2024, 1:01 PM UTC (0b6b904)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/155/358ee8f...darktears:0b6b904.html" title="Last updated on Jul 22, 2024, 1:01 PM UTC (0b6b904)">Diff</a>