### PR TITLE
Grammar: change "a hands-free" to "a hands-free experience"

### DIFF
--- a/index.html
+++ b/index.html
@@ -949,10 +949,10 @@
       </h3>
       <p>
         The device is being used for a video call web service. It can be folded
-        into the laptop <a>posture</a> to enable a hands-free when placed on a
-        surface. The UA detects the posture and the UI is enhanced. Similar
-        examples can be drafted for content to adapt to any posture. See the
-        <a href=
+        into the laptop <a>posture</a> to enable a hands-free experience when
+        placed on a surface. The UA detects the posture and the UI is enhanced.
+        Similar examples can be drafted for content to adapt to any posture.
+        See the <a href=
         "https://github.com/SamsungInternet/Explainers/blob/master/Foldables/FoldState.md#key-scenarios">
         explainer</a> for other key scenarios.
       </p><img src="images/example-videocall.svg" alt=


### PR DESCRIPTION
Just a grammar fix, nothing about the API actually changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Psychpsyo/device-posture/pull/161.html" title="Last updated on Sep 20, 2024, 10:13 AM UTC (1bb50d9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/161/f514e4a...Psychpsyo:1bb50d9.html" title="Last updated on Sep 20, 2024, 10:13 AM UTC (1bb50d9)">Diff</a>