### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,12 +108,19 @@
       </p>
     </section>
     <section id='sotd'>
+      <div class="advisement">
+        This specification is currently implemented in a single browser engine (Blink).
+        Implementer standards positions:
+        <a href="https://github.com/WebKit/standards-positions/issues/328">WebKit</a>,
+        <a href="https://github.com/mozilla/standards-positions/issues/882">Mozilla</a>.
+      </div>
       <p>
         Vendors interested in implementing this specification before it
         eventually reaches the Candidate Recommendation phase should <a href=
         "https://github.com/w3c/device-posture">subscribe to the repository on
         GitHub</a> and take part in the discussions.
       </p>
+    </section>
     </section>
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -110,9 +110,12 @@
     <section id='sotd'>
       <div class="advisement">
         This specification is currently implemented in a single browser engine (Blink).
-        Implementer standards positions:
-        <a href="https://github.com/WebKit/standards-positions/issues/328">WebKit</a>,
+        Implementer standards positions have been requested from
+        <a href="https://github.com/WebKit/standards-positions/issues/328">WebKit</a> and
         <a href="https://github.com/mozilla/standards-positions/issues/882">Mozilla</a>.
+        Refer to <a href=
+        "https://developer.mozilla.org/en-US/docs/Web/API/Device_Posture_API#browser_compatibility"
+        >MDN</a> for the latest browser compatibility data.
       </div>
       <p>
         Vendors interested in implementing this specification before it


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/device-posture/pull/172.html" title="Last updated on Apr 8, 2026, 6:34 PM UTC (d70e964)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/device-posture/172/08f131b...marcoscaceres:d70e964.html" title="Last updated on Apr 8, 2026, 6:34 PM UTC (d70e964)">Diff</a>